### PR TITLE
Hotfix hook activate deactivate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🛠️ WordPress Debug Toolkit
 
-![Versions](https://img.shields.io/badge/version-1.0.0-blue.svg)
+![Versions](https://img.shields.io/badge/version-1.5.3-blue.svg)
 ![WordPress](https://img.shields.io/badge/WordPress-6.7%2B-green.svg)
 ![PHP](https://img.shields.io/badge/PHP-.8.1%2B-purple.svg)
 ![License](https://img.shields.io/badge/license-GPL--2.0%2B-red.svg)

--- a/wp-debug-toolkit.php
+++ b/wp-debug-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Debug Toolkit
  * Plugin URI: https://github.com/cedricbb/wp-debug-toolkit
  * Description: A collection of tools to help debug WordPress and Elementor.
- * Version: 1.5.2
+ * Version: 1.5.3
  * Author: Cedric Billard
  * Author URI: https://github.com/cedricbb
  * Text Domain: wp-debug-toolkit
@@ -17,7 +17,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Définition des constantes
-const WP_DEBUG_TOOLKIT_VERSION = '1.5.2';
+const WP_DEBUG_TOOLKIT_VERSION = '1.5.3';
 define('WP_DEBUG_TOOLKIT_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('WP_DEBUG_TOOLKIT_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('WP_DEBUG_TOOLKIT_PLUGIN_BASENAME', plugin_basename(__FILE__));
@@ -41,8 +41,8 @@ if (file_exists(WP_DEBUG_TOOLKIT_PLUGIN_DIR . 'vendor/autoload.php')) {
 use WPDebugToolkit\Core\Plugin;
 
 // Hooks d'activation, de désactivation et de désinstallation
-register_activation_hook(__FILE__, array('WPDebugToolkit', 'activate'));
-register_deactivation_hook(__FILE__, array('WPDebugToolkit', 'deactivate'));
+register_activation_hook(__FILE__, array('WPDebugToolkit\Core\Plugin', 'activate'));
+register_deactivation_hook(__FILE__, array('WPDebugToolkit\Core\Plugin', 'deactivate'));
 
 // Démarrer le plugin
 add_action('plugins_loaded', function () {


### PR DESCRIPTION
Correction du Hook d'activation et désactivation du plugin, un oubli après la refactorisation PSR4 et la nouvelle structure.