### PR TITLE
Déplacement de la gestion des outils actifs vers la page Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🛠️ WordPress Debug Toolkit
 
-![Versions](https://img.shields.io/badge/version-1.5.3-blue.svg)
+![Versions](https://img.shields.io/badge/version-1.5.4-blue.svg)
 ![WordPress](https://img.shields.io/badge/WordPress-6.7%2B-green.svg)
 ![PHP](https://img.shields.io/badge/PHP-.8.1%2B-purple.svg)
 ![License](https://img.shields.io/badge/license-GPL--2.0%2B-red.svg)

--- a/assets/css/settings.css
+++ b/assets/css/settings.css
@@ -1,0 +1,129 @@
+/* Styles pour la page de paramètres */
+.wp-debug-toolkit-tools-switches {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+    gap: 20px;
+    margin-top: 20px;
+}
+
+.wp-debug-toolkit-tool-switch {
+    background: #f9f9f9;
+    border: 1px solid #e5e5e5;
+    padding: 15px;
+    border-radius: 5px;
+    transition: all 0.3s ease;
+}
+
+.wp-debug-toolkit-tool-switch:hover {
+    background: #f0f0f0;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+}
+
+.switch-row {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+}
+
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 60px;
+    height: 34px;
+    flex-shrink: 0;
+}
+
+.switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    transition: .4s;
+    border-radius: 34px;
+}
+
+.slider:before {
+    position: absolute;
+    content: "";
+    height: 26px;
+    width: 26px;
+    left: 4px;
+    bottom: 4px;
+    background-color: white;
+    transition: .4s;
+    border-radius: 50%;
+}
+
+input:checked + .slider {
+    background-color: var(--wp-debug-primary);
+}
+
+input:focus + .slider {
+    box-shadow: 0 0 1px var(--wp-debug-primary);
+}
+
+input:checked + .slider:before {
+    transform: translateX(26px);
+}
+
+.status {
+    font-weight: 500;
+    color: #555;
+    min-width: 40px;
+}
+
+.switch-label {
+    flex-grow: 1;
+}
+
+.switch-label .description {
+    color: #777;
+    font-size: 13px;
+    display: block;
+    margin-top: 5px;
+}
+
+.settings-form .button-crayola {
+    color: var(--wp-debug-primary);
+    border-color: var(--wp-debug-primary);
+    background: #fff;
+}
+
+.settings-form .button-crayola:focus {
+    box-shadow: none;
+}
+
+.settings-form .button-crayola:hover {
+    color: #fff;
+    border-color: var(--wp-debug-primary);
+    background: var(--wp-debug-primary);
+}
+/* Notification de sauvegarde */
+.wp-debug-toolkit-save-notification {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    background: #4CAF50;
+    color: white;
+    padding: 10px 20px;
+    border-radius: 4px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.2);
+    opacity: 0;
+    transform: translateY(20px);
+    transition: all 0.3s ease;
+    z-index: 9999;
+}
+
+.wp-debug-toolkit-save-notification.show {
+    opacity: 1;
+    transform: translateY(0);
+}

--- a/assets/css/tools/ElementorBlockAnalyzer/elementor-block-analyzer.css
+++ b/assets/css/tools/ElementorBlockAnalyzer/elementor-block-analyzer.css
@@ -114,7 +114,7 @@
     display: none;
 }
 
-.elementor-analyzer-table-container .wp-list-table #the-list .show-more-elements {
+.elementor-analyzer-table-container .wp-list-table #the-list .show-more-elements, .elementor-analyzer-table-container .wp-list-table #the-list .show-less-elements {
     display: inline-block;
     margin-top: 8px;
     padding: 4px 12px;
@@ -128,13 +128,13 @@
     cursor: pointer;
 }
 
-.elementor-analyzer-table-container .wp-list-table #the-list .show-more-elements:hover {
+.elementor-analyzer-table-container .wp-list-table #the-list .show-more-elements:hover, .elementor-analyzer-table-container .wp-list-table #the-list .show-less-elements:hover {
     color: #ffffff;
     background-color: var(--wp-debug-primary);
     border-color: var(--wp-debug-primary);
 }
 
-.elementor-analyzer-table-container .wp-list-table #the-list .show-more-elements:focus {
+.elementor-analyzer-table-container .wp-list-table #the-list .show-more-elements:focus, .elementor-analyzer-table-container .wp-list-table #the-list .show-less-elements:focus {
     box-shadow: none;
 }
 

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,18 +1,41 @@
 /**
- * Script pour la personnalisation du tableau de bord WP Debug Toolkit
+ * Script principal pour WP Debug Toolkit
  */
 (function($) {
     'use strict';
 
-    // Objet principal du customizer
-    var WPDebugToolkitCustomizer = {
+    // Objet principal pour les fonctionnalités du plugin
+    var WPDebugToolkit = {
         /**
          * Initialisation
          */
         init: function() {
+            // Initialiser les fonctionnalités du tableau de bord si nous sommes sur cette page
+            if ($('.wp-debug-toolkit-dashboard').length) {
+                this.initDashboard();
+            }
+
+            // Initialiser les fonctionnalités de la page paramètres si nous sommes sur cette page
+            if ($('.wp-debug-toolkit-tools-switches').length) {
+                this.initSettings();
+            }
+        },
+
+        /**
+         * Initialise les fonctionnalités du tableau de bord
+         */
+        initDashboard: function() {
             this.initSortable();
-            this.initMetaboxToggles();
-            this.bindEvents();
+            this.initToolToggles();
+            this.bindDashboardEvents();
+        },
+
+        /**
+         * Initialise les fonctionnalités de la page paramètres
+         */
+        initSettings: function() {
+            this.initToolSwitches();
+            this.bindSettingsEvents();
         },
 
         /**
@@ -28,7 +51,7 @@
                 delay: 150,
                 tolerance: 'pointer',
                 update: function(event, ui) {
-                    WPDebugToolkitCustomizer.saveToolsOrder();
+                    WPDebugToolkit.saveToolsOrder();
                 }
             }).disableSelection();
         },
@@ -36,7 +59,7 @@
         /**
          * Initialise les toggles pour montrer/cacher des outils
          */
-        initMetaboxToggles: function() {
+        initToolToggles: function() {
             // Ajouter des icônes de toggle dans les en-têtes d'outils
             $('.wp-debug-toolkit-tool-card-header').append(
                 '<button class="wp-debug-toolkit-tool-toggle dashicons dashicons-visibility" aria-expanded="true"></button>'
@@ -45,7 +68,7 @@
             // Appliquer l'état sauvegardé (visible/caché) pour chaque outil
             $('.wp-debug-toolkit-tool-card').each(function() {
                 var toolId = $(this).data('tool-id');
-                var isHidden = WPDebugToolkitCustomizer.getToolUserPreference(toolId, 'hidden');
+                var isHidden = WPDebugToolkit.getToolUserPreference(toolId, 'hidden');
 
                 if (isHidden) {
                     $(this).addClass('wp-debug-toolkit-tool-hidden');
@@ -58,9 +81,16 @@
         },
 
         /**
-         * Lie les événements aux éléments
+         * Initialise les switches des outils sur la page paramètres
          */
-        bindEvents: function() {
+        initToolSwitches: function() {
+            // Déjà géré par le script inline dans settings.php
+        },
+
+        /**
+         * Lie les événements aux éléments du tableau de bord
+         */
+        bindDashboardEvents: function() {
             // Clic sur les toggles d'outils pour montrer/cacher
             $(document).on('click', '.wp-debug-toolkit-tool-toggle', function(e) {
                 e.preventDefault();
@@ -76,54 +106,16 @@
                 $(this).attr('aria-expanded', isHidden ? 'true' : 'false');
 
                 // Sauvegarder la préférence
-                WPDebugToolkitCustomizer.saveToolUserPreference(toolId, 'hidden', !isHidden);
+                WPDebugToolkit.saveToolUserPreference(toolId, 'hidden', !isHidden);
             });
+        },
 
-            // Traitement AJAX complémentaire pour les options d'écran
-            $(document).on('click', '#wp-debug-toolkit-save-screen-options', function(e) {
-                // Ne pas appeler preventDefault() ici pour permettre la soumission du formulaire
-
-                // Collecter les outils actifs pour AJAX
-                var activeTools = {};
-
-                // Parcourir toutes les checkboxes et récupérer leur état
-                $('#wp-debug-toolkit-available-tools input[type="checkbox"]').each(function() {
-                    var toolId = $(this).val();
-
-                    // S'assurer que l'ID est correct
-                    if (!toolId || toolId === "1") {
-                        // Essayer d'extraire l'ID à partir du nom
-                        var nameMatch = $(this).attr('name').match(/wp-debug-toolkit-tool-(.*?)$/);
-                        if (nameMatch && nameMatch[1]) {
-                            toolId = nameMatch[1];
-                        }
-                    }
-
-                    if (toolId && toolId !== "1") {
-                        activeTools[toolId] = $(this).is(':checked');
-                    }
-                });
-
-                // Afficher un feedback visuel
-                WPDebugToolkitCustomizer.showNotification();
-
-                // Log pour debug
-                console.log('Tools to save via AJAX:', activeTools);
-
-                // Envoyer les données via AJAX en parallèle
-                $.ajax({
-                    url: ajaxurl,
-                    type: 'POST',
-                    data: {
-                        action: 'wp_debug_toolkit_save_active_tools',
-                        active_tools: activeTools,
-                        nonce: wp_debug_toolkit_customizer.nonce
-                    },
-                    success: function(response) {
-                        console.log('AJAX response:', response);
-                    }
-                });
-            });
+        /**
+         * Lie les événements aux éléments de la page paramètres
+         */
+        bindSettingsEvents: function() {
+            // Les événements sont déjà gérés par le script inline dans settings.php
+            // et par la soumission du formulaire
         },
 
         /**
@@ -147,7 +139,7 @@
                 success: function(response) {
                     if (response.success) {
                         // Afficher une notification de sauvegarde
-                        WPDebugToolkitCustomizer.showNotification();
+                        WPDebugToolkit.showNotification();
                     }
                 }
             });
@@ -170,7 +162,7 @@
                 success: function(response) {
                     if (response.success) {
                         // Afficher une notification de sauvegarde
-                        WPDebugToolkitCustomizer.showNotification();
+                        WPDebugToolkit.showNotification();
                     }
                 }
             });
@@ -181,7 +173,8 @@
          */
         getToolUserPreference: function(toolId, prefKey) {
             // Cette fonction utilise les préférences chargées côté serveur et injectées dans la page
-            if (typeof wp_debug_toolkit_customizer.user_preferences !== 'undefined' &&
+            if (typeof wp_debug_toolkit_customizer !== 'undefined' &&
+                typeof wp_debug_toolkit_customizer.user_preferences !== 'undefined' &&
                 typeof wp_debug_toolkit_customizer.user_preferences[toolId] !== 'undefined' &&
                 typeof wp_debug_toolkit_customizer.user_preferences[toolId][prefKey] !== 'undefined') {
                 return wp_debug_toolkit_customizer.user_preferences[toolId][prefKey];
@@ -211,10 +204,7 @@
 
     // Initialiser lorsque le document est prêt
     $(document).ready(function() {
-        // Vérifier si nous sommes sur la page du tableau de bord du plugin
-        if ($('.wp-debug-toolkit-dashboard').length) {
-            WPDebugToolkitCustomizer.init();
-        }
+        WPDebugToolkit.init();
     });
 
 })(jQuery);

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -26,7 +26,6 @@
          */
         initDashboard: function() {
             this.initSortable();
-            this.initToolToggles();
             this.bindDashboardEvents();
         },
 
@@ -54,30 +53,6 @@
                     WPDebugToolkit.saveToolsOrder();
                 }
             }).disableSelection();
-        },
-
-        /**
-         * Initialise les toggles pour montrer/cacher des outils
-         */
-        initToolToggles: function() {
-            // Ajouter des icônes de toggle dans les en-têtes d'outils
-            $('.wp-debug-toolkit-tool-card-header').append(
-                '<button class="wp-debug-toolkit-tool-toggle dashicons dashicons-visibility" aria-expanded="true"></button>'
-            );
-
-            // Appliquer l'état sauvegardé (visible/caché) pour chaque outil
-            $('.wp-debug-toolkit-tool-card').each(function() {
-                var toolId = $(this).data('tool-id');
-                var isHidden = WPDebugToolkit.getToolUserPreference(toolId, 'hidden');
-
-                if (isHidden) {
-                    $(this).addClass('wp-debug-toolkit-tool-hidden');
-                    $(this).find('.wp-debug-toolkit-tool-toggle')
-                        .removeClass('dashicons-visibility')
-                        .addClass('dashicons-hidden')
-                        .attr('aria-expanded', 'false');
-                }
-            });
         },
 
         /**

--- a/assets/js/tools/ElementorBlockAnalyzer/elementor-block-analyzer.js
+++ b/assets/js/tools/ElementorBlockAnalyzer/elementor-block-analyzer.js
@@ -1,24 +1,34 @@
 jQuery(document).ready(function($) {
+    // Variables pour les traductions
+    const showLessText = 'Voir moins';
+
     // Gestion du show/hide pour les listes d'éléments
     $('.show-more-elements').on('click', function(e) {
         e.preventDefault();
 
         const container = $(this).closest('.elements-container');
         const hiddenElements = container.find('.hidden-element');
+        const count = parseInt($(this).data('count'), 10);
+        const singularTemplate = $(this).data('singular');
+        const pluralTemplate = $(this).data('plural');
 
         // Si les éléments sont cachés, on les affiche
         if (hiddenElements.first().is(':hidden')) {
-            hiddenElements.fadeIn();
-            $(this).text(__('Voir moins', 'wp-debug-toolkit'));
+            hiddenElements.show();
+            $(this).text(showLessText);
         } else {
             // Sinon on les cache
-            hiddenElements.fadeOut();
-            // Recréer le texte "Voir plus" avec le bon nombre d'éléments
-            const remainingCount = hiddenElements.length;
-            const text = remainingCount === 1
-                ? elementorWidgetsTableL10n.showMore.singular
-                : elementorWidgetsTableL10n.showMore.plural;
-            $(this).text(text.replace('%d', remainingCount));
+            hiddenElements.hide();
+
+            // Déterminer le texte correct
+            let newText;
+            if (count === 1) {
+                newText = singularTemplate;
+            } else {
+                newText = pluralTemplate.replace('%d', count);
+            }
+
+            $(this).text(newText);
         }
     });
 
@@ -38,7 +48,7 @@ jQuery(document).ready(function($) {
     $searchInput.on('input', performSearch);
 
     $searchInput.on('keypress', function(e) {
-        if (e.wich === 13) {
+        if (e.which === 13) {
             e.preventDefault();
             clearTimeout(searchTimeout);
             $searchForm.submit();

--- a/src/Admin/Page/Settings.php
+++ b/src/Admin/Page/Settings.php
@@ -2,90 +2,26 @@
 
 namespace WPDebugToolkit\Admin\Page;
 
+use WPDebugToolkit\Tool\ToolManager;
+
 class Settings extends AbstractPage
 {
     public function __construct()
     {
         parent::__construct('settings', __('Paramètres', 'wp-debug-toolkit'), 'dashicons-admin-settings');
+        add_action('admin_enqueue_scripts', [$this, 'enqueueAssets']);
     }
 
     public function render(): void
     {
-        ?>
-        <style>
-            .switch {
-                position: relative;
-                display: inline-block;
-                width: 60px;
-                height: 34px;
-            }
-
-            .switch input {
-                opacity: 0;
-                width: 0;
-                height: 0;
-            }
-
-            .slider {
-                position: absolute;
-                cursor: pointer;
-                top: 0;
-                left: 0;
-                right: 0;
-                bottom: 0;
-                background-color: #ccc;
-                transition: .4s;
-                border-radius: 34px;
-            }
-
-            .slider:before {
-                position: absolute;
-                content: "";
-                height: 26px;
-                width: 26px;
-                left: 4px;
-                bottom: 4px;
-                background-color: white;
-                transition: .4s;
-                border-radius: 50%;
-            }
-
-            input:checked + .slider {
-                background-color: var(--wp-debug-primary);
-            }
-
-            input:focus + .slider {
-                box-shadow: 0 0 1px var(--wp-debug-primary);
-            }
-
-            input:checked + .slider:before {
-                transform: translateX(26px);
-            }
-
-            .status {
-                font-weight: 500;
-                color: #555;
-                min-width: 60px;
-            }
-
-            .switch-label {
-                font-size: 16px;
-                color: #333;
-                user-select: none;
-            }
-        </style>
-        <div class="switch-container">
-            <div class="switch-row">
-                <label class="switch">
-                    <input type="checkbox" id="toggle1">
-                    <span class="slider"></span>
-                </label>
-            </div>
-        </div>
-
-        <?php
         // Traiter le formulaire de paramètres si soumis
         $this->processSettingsForm();
+
+        // Récupérer tous les outils disponibles
+        $allTools = ToolManager::getAllAvailableTools();
+
+        // Filtrer les outils filtrés pour l'affichage
+        $filterTools = $this->filterSettingsTools($allTools);
 
         // Récupérer les paramètres actuels
         $settings = get_option('wp_debug_toolkit_settings', [
@@ -93,6 +29,15 @@ class Settings extends AbstractPage
             'enable_logging' => false,
             'developer_mode' => false
         ]);
+
+        // Récupérer les outils actifs pour l'utilisateur
+        $activeTools = get_user_meta(get_current_user_id(), 'wp_debug_toolkit_active_tools', true);
+        if (!is_array($activeTools)) {
+            $activeTools = [];
+            foreach ($allTools as $toolId => $tool) {
+                $activeTools[$toolId] = $tool['active'];
+            }
+        }
 
         // Inclure la vue des paramètres
         require_once WP_DEBUG_TOOLKIT_PLUGIN_DIR . '/src/Admin/View/settings.php';
@@ -103,23 +48,73 @@ class Settings extends AbstractPage
         // Vérifie si le formulaire a été soumis
         if (isset($_POST['wp_debug_toolkit_settings_submit'])) {
             // Vérifie le nonce
-            if (!$this->verifyNonce($_POST['wp_debug_toolkit_settings_nonce'] ?? '')) {
+            if (!isset($_POST['wp_debug_toolkit_settings_nonce']) ||
+                !wp_verify_nonce($_POST['wp_debug_toolkit_settings_nonce'], 'wp_debug_toolkit_settings')) {
                 $this->showNotice(__('Erreur de sécurité. Veuillez réessayer.', 'wp-debug-toolkit'), 'error');
                 return;
             }
 
-            // Récupère et nettoie les données
+            // Récupère et nettoie les données des paramètres généraux
             $settings = [
                 'acces_level' => sanitize_text_field($_POST['acces_level'] ?? 'manage_options'),
                 'enable_logging' => isset($_POST['enable_logging']),
                 'developer_mode' => isset($_POST['developer_mode'])
             ];
 
-            // Enregistre les paramètres
+            // Enregistre les paramètres généraux
             update_option('wp_debug_toolkit_settings', $settings);
+
+            // Traitement des outils actifs
+            $allTools = ToolManager::getAllAvailableTools();
+            $activeTools = [];
+
+            // Initialiser tous les outils comme inactifs
+            foreach ($allTools as $toolId => $tool) {
+                $activeTools[$toolId] = false;
+            }
+
+            // Activer les outils sélectionnés
+            if (isset($_POST['active_tools']) && is_array($_POST['active_tools'])) {
+                foreach ($_POST['active_tools'] as $toolId) {
+                    if (isset($allTools[$toolId])) {
+                        $activeTools[$toolId] = true;
+                    }
+                }
+            }
+
+            // Sauvegarder dans les métadonnées de l'utilisateur
+            update_user_meta(get_current_user_id(), 'wp_debug_toolkit_active_tools', $activeTools);
+
+            // Mettre également à jour l'option globale pour les nouveaux utilisateurs
+            $toolSettings = get_option('wp_debug_toolkit_tools', []);
+            $toolSettings = array_merge($toolSettings, $activeTools);
+            update_option('wp_debug_toolkit_tools', $toolSettings);
 
             // Affiche un message de succès
             $this->showNotice(__('Paramètres enregistrés avec succès.', 'wp-debug-toolkit'), 'success');
         }
+    }
+
+    public static function filterSettingsTools(array $tools): array
+    {
+        return $tools;
+    }
+
+    public function enqueueAssets(string $hook): void
+    {
+        // Enqueue CSS
+        wp_enqueue_style(
+            'wp-debug-toolkit-settings-css',
+            WP_DEBUG_TOOLKIT_PLUGIN_URL . 'assets/css/settings.css',
+            [],
+            WP_DEBUG_TOOLKIT_VERSION . '-' . time()
+        );
+        // Enqueuejs
+        wp_enqueue_script(
+            'wp-debug-toolkit-settings-js',
+            WP_DEBUG_TOOLKIT_PLUGIN_URL . 'assets/js/settings.js',
+            [],
+            WP_DEBUG_TOOLKIT_VERSION . '-' . time()
+        );
     }
 }

--- a/src/Admin/View/settings.php
+++ b/src/Admin/View/settings.php
@@ -1,0 +1,101 @@
+<div class="wrap">
+    <h1><?php echo esc_html(get_admin_page_title()); ?></h1>
+
+    <form method="post" action="" class="settings-form">
+        <?php wp_nonce_field('wp_debug_toolkit_settings', 'wp_debug_toolkit_settings_nonce'); ?>
+
+        <div class="metabox-holder">
+            <!-- Paramètres généraux -->
+            <div class="postbox">
+                <h2 class="hndle"><span><?php _e('Paramètres généraux', 'wp-debug-toolkit'); ?></span></h2>
+                <div class="inside">
+                    <table class="form-table">
+                        <tr>
+                            <th scope="row">
+                                <label for="acces_level"><?php _e('Niveau d\'accès requis', 'wp-debug-toolkit'); ?></label>
+                            </th>
+                            <td>
+                                <select name="acces_level" id="acces_level">
+                                    <option value="manage_options" <?php selected($settings['acces_level'], 'manage_options'); ?>><?php _e('Administrateur', 'wp-debug-toolkit'); ?></option>
+                                    <option value="edit_pages" <?php selected($settings['acces_level'], 'edit_pages'); ?>><?php _e('Éditeur', 'wp-debug-toolkit'); ?></option>
+                                    <option value="publish_posts" <?php selected($settings['acces_level'], 'publish_posts'); ?>><?php _e('Auteur', 'wp-debug-toolkit'); ?></option>
+                                </select>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><?php _e('Journalisation', 'wp-debug-toolkit'); ?></th>
+                            <td>
+                                <label for="enable_logging">
+                                    <input type="checkbox" name="enable_logging" id="enable_logging" <?php checked($settings['enable_logging']); ?>>
+                                    <?php _e('Activer la journalisation des actions', 'wp-debug-toolkit'); ?>
+                                </label>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><?php _e('Mode développeur', 'wp-debug-toolkit'); ?></th>
+                            <td>
+                                <label for="developer_mode">
+                                    <input type="checkbox" name="developer_mode" id="developer_mode" <?php checked($settings['developer_mode']); ?>>
+                                    <?php _e('Activer les fonctionnalités avancées de développement', 'wp-debug-toolkit'); ?>
+                                </label>
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+
+            <!-- Gestion des outils -->
+            <div class="postbox">
+                <h2 class="hndle"><span><?php _e('Activer/Désactiver les outils', 'wp-debug-toolkit'); ?></span></h2>
+                <div class="inside">
+                    <p><?php _e('Utilisez les switches ci-dessous pour activer ou désactiver les outils disponibles.', 'wp-debug-toolkit'); ?></p>
+
+                    <div class="wp-debug-toolkit-tools-switches">
+                        <?php foreach ($allTools as $toolId => $tool): ?>
+                            <div class="wp-debug-toolkit-tool-switch" data-tool-id="<?php echo esc_attr($toolId); ?>">
+                                <div class="switch-row">
+                                    <label class="switch">
+                                        <input type="checkbox" id="tool-<?php echo esc_attr($toolId); ?>" name="active_tools[]" value="<?php echo esc_attr($toolId); ?>" <?php checked(isset($activeTools[$toolId]) && $activeTools[$toolId]); ?>>
+                                        <span class="slider"></span>
+                                    </label>
+                                    <span class="status" id="status-<?php echo esc_attr($toolId); ?>"><?php echo (isset($activeTools[$toolId]) && $activeTools[$toolId]) ? __('On', 'wp-debug-toolkit') : __('Off', 'wp-debug-toolkit'); ?></span>
+                                    <span class="switch-label">
+                                        <strong><?php echo esc_html($tool['title']); ?></strong><br>
+                                        <span class="description"><?php echo esc_html($tool['description']); ?></span>
+                                    </span>
+                                </div>
+                            </div>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <p class="submit">
+            <input type="submit" name="wp_debug_toolkit_settings_submit" id="submit" class="button button-crayola" value="<?php _e('Enregistrer les modifications', 'wp-debug-toolkit'); ?>">
+        </p>
+    </form>
+</div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        // Initialiser chaque switch
+        document.querySelectorAll('.wp-debug-toolkit-tool-switch').forEach(function(switchContainer) {
+            const toolId = switchContainer.dataset.toolId;
+            const checkbox = document.getElementById('tool-' + toolId);
+            const statusElement = document.getElementById('status-' + toolId);
+
+            // Mettre à jour le statut initial
+            updateStatus(checkbox, statusElement);
+
+            // Ajouter l'événement de changement
+            checkbox.addEventListener('change', function() {
+                updateStatus(this, statusElement);
+            });
+        });
+
+        function updateStatus(checkbox, statusElement) {
+            statusElement.textContent = checkbox.checked ? 'On' : 'Off';
+        }
+    });
+</script>

--- a/src/Tool/ElementorBlockAnalyzer/ElementorBlockAnalyzer.php
+++ b/src/Tool/ElementorBlockAnalyzer/ElementorBlockAnalyzer.php
@@ -72,7 +72,7 @@ class ElementorBlockAnalyzer extends AbstractTool
             );
             wp_enqueue_script(
                 'elementor-block-analyzer-widget-detail',
-                WP_DEBUG_TOOLKIT_PLUGIN_URL . 'assets/js/tools/ElementorBlockAnalyzer/elementor-block-analyzer-widget-detail.js',
+                WP_DEBUG_TOOLKIT_PLUGIN_URL . 'assets/js/tools/ElementorBlockAnalyzer/elementor-block-analyzer-widget-details.js',
                 ['jquery', 'thickbox', 'postbox'],
                 WP_DEBUG_TOOLKIT_VERSION . '-' . time(),
                 true

--- a/src/Tool/ElementorBlockAnalyzer/ElementorWidgetsTable.php
+++ b/src/Tool/ElementorBlockAnalyzer/ElementorWidgetsTable.php
@@ -319,17 +319,24 @@ final class ElementorWidgetsTable extends WP_List_Table
 
         if ($count > $initial_display) {
             $remaining = $count - $initial_display;
-            $output .= sprintf(
-                '<a class="show-more-elements" href="#">%s</a>',
-                sprintf(
-                    _n(
-                        'Voir %d élément de plus',
-                        'Voir %d éléments de plus',
-                        $remaining,
-                        'wp-debug-toolkit'
-                    ),
+
+            // Déterminer le message correct en fonction du nombre
+            if ($remaining === 1) {
+                $message = __('Voir 1 élément de plus', 'wp-debug-toolkit');
+            } else {
+                $message = sprintf(
+                /* translators: %d: number of elements */
+                    __('Voir %d éléments de plus', 'wp-debug-toolkit'),
                     $remaining
-                )
+                );
+            }
+
+            $output .= sprintf(
+                '<a class="show-more-elements" href="#" data-count="%d" data-singular="%s" data-plural="%s">%s</a>',
+                $remaining,
+                esc_attr__('Voir 1 élément de plus', 'wp-debug-toolkit'),
+                esc_attr__('Voir %d éléments de plus', 'wp-debug-toolkit'),
+                $message
             );
         }
 

--- a/src/Tool/ElementorBlockAnalyzer/View/content.php
+++ b/src/Tool/ElementorBlockAnalyzer/View/content.php
@@ -166,40 +166,17 @@ $actionUrl = admin_url('admin-ajax.php?action=wp_debug_toolkit_analyze_elementor
                             if (response.success) {
                                 location.reload();
                             } else {
-                                alert('<?php _e('Erreur lors de l\'analyse. Veuillez réessayer.', 'wp-debug-toolkit'); ?>');
+                                alert('Erreur lors de l\'analyse. Veuillez réessayer.');
                                 $button.prop('disabled', false);
                                 $button.find('.dashicons').removeClass('spin');
                             }
                         },
                         error: function() {
-                            alert('<?php _e('Erreur lors de l\'analyse. Veuillez réessayer.', 'wp-debug-toolkit'); ?>');
+                            alert('Erreur lors de l\'analyse. Veuillez réessayer.');
                             $button.prop('disabled', false);
                             $button.find('.dashicons').removeClass('spin');
                         }
                     });
-                });
-
-                // Afficher/masquer les éléments
-                $('.elementor-analyzer-table-container').on('click', '.show-more-elements', function(e) {
-                    e.preventDefault();
-                    var $container = $(this).closest('.elements-container');
-                    $container.find('.hidden-element').show();
-                    $(this).text('<?php _e('Voir moins', 'wp-debug-toolkit'); ?>');
-                    $(this).removeClass('show-more-elements').addClass('show-less-elements');
-                });
-
-                $('.elementor-analyzer-table-container').on('click', '.show-less-elements', function(e) {
-                    e.preventDefault();
-                    var $container = $(this).closest('.elements-container');
-                    $container.find('.hidden-element').hide();
-
-                    var hiddenCount = $container.find('.hidden-element').length;
-                    var text = hiddenCount === 1
-                        ? '<?php _e('Voir 1 élément de plus', 'wp-debug-toolkit'); ?>'
-                        : '<?php echo sprintf(__('Voir %s éléments de plus', 'wp-debug-toolkit'), "' + hiddenCount + '"); ?>';
-
-                    $(this).text(text);
-                    $(this).removeClass('show-less-elements').addClass('show-more-elements');
                 });
             });
         </script>

--- a/wp-debug-toolkit.php
+++ b/wp-debug-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Debug Toolkit
  * Plugin URI: https://github.com/cedricbb/wp-debug-toolkit
  * Description: A collection of tools to help debug WordPress and Elementor.
- * Version: 1.5.3
+ * Version: 1.5.4
  * Author: Cedric Billard
  * Author URI: https://github.com/cedricbb
  * Text Domain: wp-debug-toolkit
@@ -17,7 +17,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Définition des constantes
-const WP_DEBUG_TOOLKIT_VERSION = '1.5.3';
+const WP_DEBUG_TOOLKIT_VERSION = '1.5.4';
 define('WP_DEBUG_TOOLKIT_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('WP_DEBUG_TOOLKIT_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('WP_DEBUG_TOOLKIT_PLUGIN_BASENAME', plugin_basename(__FILE__));


### PR DESCRIPTION
- Déplacement de la gestion des outils actifs vers la page Settings
- Création d'une interface utilisateur avec des switches élégants
- Simplification du JavaScript pour gérer ces fonctionnalités 
- Suppression du code des options d'écran qui n'est plus nécessaire

Ces modifications offrent une expérience utilisateur plus intuitive en centralisant la gestion des outils actifs dans la page des paramètres avec des switches visuellement attrayants au lieu des cases à cocher standard dans les options d'écran.